### PR TITLE
AtBeginDocument zamenjaj z AfterEndPreamble

### DIFF
--- a/delo_diplomskega_seminarja/fmfdelo.cls
+++ b/delo_diplomskega_seminarja/fmfdelo.cls
@@ -6,7 +6,7 @@
 %-----------------------------------------------------------------------------
 
 % Nalozimo pakete, ki ponujajo enostavno programiranje.
-\RequirePackage{ifthen, keyval}
+\RequirePackage{etoolbox, ifthen, keyval}
 
 % Definiramo pomozne ukaze.
 \newcommand{\@ifthen}[2]{\ifthenelse{#1}{#2}{\relax}}
@@ -134,7 +134,7 @@
 \newcommand{\geslo}[2]{\noindent\textbf{#1}\hspace*{3mm}\hangindent=\parindent\hangafter=1 #2\par}
 
 % Ukaz za izpis začetnih strani.
-\AtBeginDocument{%
+\AfterEndPreamble{%
 
 % od tod do povzetka ne spreminjaj nicesar
 \thispagestyle{empty}


### PR DESCRIPTION
Nekateri študentje ob uporabi paketov `tikz` in `minted` dobivajo napako

```latex
! Undefined control sequence.
\set@color ...\@pdfcolorstack push{\current@color
}\aftergroup \reset@color
l.55 \begin{document}
```

Kot gledam na [LaTeX Stack Exchange](https://tex.stackexchange.com/questions/102927/undefined-control-sequence-with-color-package-in-custom-latex-document-class), je težava v tem, da se v ukazu `\AtBeginDocument` ne sme staviti besedila, kar pa mi počnemo z naslovom. Predlagajo, da se namesto tega uporabi `\AfterEndPreamble` iz paketa `etoolbox`.

Predlagam torej to zamenjavo, hkrati pa razmišljam, ali bi v kakšnem od novih hookov, ki jih ponuja `etoolbox`, lahko poklicali tudi `\nastaviMetaPodatke`, da tega ne bi bilo treba narediti ročno.