### PR TITLE
Update fmf-sl.bst

### DIFF
--- a/magistrsko_delo/fmf-sl.bst
+++ b/magistrsko_delo/fmf-sl.bst
@@ -491,17 +491,12 @@ FUNCTION {format.note}
 }
 
 FUNCTION {format.title}
-{ title
-  duplicate$ empty$ 'skip$
-    { "t" change.case$ }
-  if$
-  "title" bibinfo.check
-  duplicate$ empty$ 'skip$
-    {
-      emphasize
-    }
+{ title empty$
+    { "" }
+    { title }
   if$
 }
+
 FUNCTION {output.bibitem}
 { newline$
   "\bibitem{" write$


### PR DESCRIPTION
Naslovi literatur (članki, knjige ...) so pred popravkom bili spremenjeni v lowecase črke (npr. MCTS -> Mcts).  Sedaj so črke glede na zapis v .bib datoteki ustrezno lowercase ali uppercase.