### PR TITLE
XMP generiral prek paketa pdfx

### DIFF
--- a/delo_diplomskega_seminarja/PredlogaDela.tex
+++ b/delo_diplomskega_seminarja/PredlogaDela.tex
@@ -36,8 +36,6 @@
 \kljucnebesede{} % navedite nekaj ključnih pojmov, ki nastopajo v delu
 \keywords{} % angleški prevod ključnih besed
 
-\zapisiMetaPodatke  % poskrbi za metapodatke in veljaven PDF/A-1b standard
-
 % aktivirajte pakete, ki jih potrebujete
 % \usepackage{tikz}
 
@@ -45,7 +43,9 @@
 \newcommand{\R}{\mathbb R}
 \newcommand{\N}{\mathbb N}
 \newcommand{\Z}{\mathbb Z}
-\newcommand{\C}{\mathbb C}
+% Paket hyperref definira ukaz \C, zato ga moramo povoziti, če ga želimo
+% uporabljati za kompleksna števila.
+\renewcommand{\C}{\mathbb C}
 \newcommand{\Q}{\mathbb Q}
 
 % matematične operatorje deklarirajte kot take, da jih bo Latex pravilno stavil

--- a/delo_diplomskega_seminarja/VzorecDela.tex
+++ b/delo_diplomskega_seminarja/VzorecDela.tex
@@ -38,8 +38,6 @@ vsebine.}
 \kljucnebesede{navedite nekaj ključnih pojmov, ki nastopajo v delu} % navedite nekaj ključnih pojmov, ki nastopajo v delu
 \keywords{angleški prevod ključnih besed} % angleški prevod ključnih besed
 
-\zapisiMetaPodatke  % poskrbi za metapodatke in veljaven PDF/A-1b standard
-
 % aktivirajte pakete, ki jih potrebujete
 % \usepackage{tikz}
 
@@ -47,7 +45,9 @@ vsebine.}
 \newcommand{\R}{\mathbb R}
 \newcommand{\N}{\mathbb N}
 \newcommand{\Z}{\mathbb Z}
-\newcommand{\C}{\mathbb C}
+% Paket hyperref definira ukaz \C, zato ga moramo povoziti, če ga želimo
+% uporabljati za kompleksna števila.
+\renewcommand{\C}{\mathbb C}
 \newcommand{\Q}{\mathbb Q}
 
 % matematične operatorje deklarirajte kot take, da jih bo Latex pravilno stavil

--- a/delo_diplomskega_seminarja/fmfdelo.cls
+++ b/delo_diplomskega_seminarja/fmfdelo.cls
@@ -5,8 +5,15 @@
 %                       Pomozni ukazi in spremenljivke
 %-----------------------------------------------------------------------------
 
+% Nalozimo paket za zagotavljanje PDF/A-1B (ustrezni fonti, barvni profili, UTF-8 zapis simbolov, ...)
+\RequirePackage[a-1b]{pdfx}
+
 % Nalozimo pakete, ki ponujajo enostavno programiranje.
 \RequirePackage{etoolbox, ifthen, keyval}
+
+% Nalozimo paket za ustvarjanje .xmpdata datoteke, ki jo potrebuje paket pdfx
+% Okolja filecontents ne moremo uporabiti, ker se ga ne da poklicati v makroju.
+\RequirePackage{newfile}
 
 % Definiramo pomozne ukaze.
 \newcommand{\@ifthen}[2]{\ifthenelse{#1}{#2}{\relax}}
@@ -43,18 +50,6 @@
   \RequirePackage[slovene]{babel}
   \RequirePackage[utf8]{inputenc}
   \RequirePackage[T1]{fontenc}
-  \RequirePackage{silence}
-  \WarningFilter{hyperref}{Option}
-  % Paket hyperxmp nalozimo, da bo iz \hypersetup podatkov samodejno napolnil XMP podatke,
-  % ki so potrebni za PDF/A datoteke. S tem se izognemo generiranju datoteke .xmpdata, ki
-  % jo sicer potrebuje paket pdfx.
-  \RequirePackage{hyperxmp}
-  % Paketu hyperref podamo moznost pdfa, da ne dela linkov, ki bi lahko pokvarili PDF/A,
-  % drugi dve moznosti pa natancno specificirata verzijo.
-  % Paket hyperxmp naceloma ze nalozi hyperref, vendar ga vseeno nalozimo se sami,
-  % da dolocimo verzijo, hkrati pa podpremo stare verzije hyperxmpja, ki tega ne
-  % nalozijo.
-  \RequirePackage[pdfa,pdfapart=1,pdfaconformance=B]{hyperref}
 
   % algorithms
   \RequirePackage{algpseudocode}  % za psevdokodo
@@ -66,22 +61,6 @@
   \algnewcommand\algorithmicforeach{\textbf{for each}}
   \algrenewtext{For}[3]{\algorithmicfor\ #1 $\gets$ #2\ \algorithmicto\ #3\ \algorithmicdo}
   \algdef{S}[FOR]{ForEach}[2]{\algorithmicforeach\ #1\ \algorithmicin\ #2\ \algorithmicdo}
-}
-\newcommand{\zapisiMetaPodatke}{
-  \hypersetup{pdfencoding=auto, psdextra, pdflang=sl, % ali 'en' za anglesicno
-    bookmarksopen, bookmarksdepth=3,
-    pdfauthor=\@avtor,
-    pdftitle=\@naslov,
-    pdfproducer={pdfTeX},
-    pdfsubject={matematika},
-    pdfkeywords=\@kljucnebesede}
-  % Paket hyperref definira ukaz \C, ki ga zelo zelo verjetno nihce ne bo rabil,
-  % zato ga odstranimo, da lahko \C uporabljamo za kompleksna stevila. Odstraniti
-  % ga moramo sele tu, saj \hypersetup ocitno makro ponovno definira
-  \let\C\undefined
-  % Paket pdfx moramo naloziti, ker pravilno nastavljeni metapodatki se niso dovolj za
-  % PDF/A. Nastavljeni morajo biti fonti, barvni profili, ... in za vse to poskrbi pdfx.
-  \RequirePackage[a-1b]{pdfx}
 }
 
 %-----------------------------------------------------------------------------
@@ -143,9 +122,19 @@
 \newtheorem{izrek}[definicija]{Izrek}
 \newtheorem{trditev}[definicija]{Trditev}
 \newtheorem{posledica}[definicija]{Posledica}
-
 % ukaz za slovarsko geslo
 \newcommand{\geslo}[2]{\noindent\textbf{#1}\hspace*{3mm}\hangindent=\parindent\hangafter=1 #2\par}
+
+\AtEndPreamble{%
+\newoutputstream{xmpdatafile}
+\openoutputfile{\jobname.xmpdata}{xmpdatafile}
+\addtostream{xmpdatafile}{%
+\protect\Title{\@naslov}
+\protect\Author{\@avtor}
+\protect\Keywords{\@kljucnebesede}
+\protect\Subject{matematika}
+}
+}
 
 % Ukaz za izpis začetnih strani.
 \AfterEndPreamble{%


### PR DESCRIPTION
Pred tem se je XMP, torej del PDFja, ki vsebuje XML z metapodatki, generiral dvakrat - enkrat prek paketa `hyperxmp` skupaj s `hyperref`, kjer so bili pravi podatki, drugič prek `pdfx`, kjer so bili neki privzeti podatki. Eni programi so prebrali enega, drugi drugega. Zdaj se generira samo enkrat, prek `pdfx` in se potem tudi npr. pokaže pravilno v Appleovem Previewu. Poleg tega sem uporabil paket `newfile`, s katerim lahko v preambuli pripravim `.xmpdata` in ni več treba ročno klicati `\zapisiMetapodatke`. Zaenkrat sem popravil samo paket za diplome, bi pa na ta paket prešel tudi z magistrskimi deli.