### PR TITLE
Stvarno kazalo in VS Code nastavitve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,6 @@ TSWLatexianTemp*
 *-tags.tex
 
 *.bak
+
+# build folder
+build/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,56 @@
+{
+    "latex-workshop.latex.outDir": "build",
+    "latex-workshop.latex.recipes": [
+        {
+            "name": "pdflatex->bibtex->makeindex->pdflatex",
+            "tools": [
+                "pdflatex",
+                "bibtex",
+                "makeindex",
+                "pdflatex",
+                "pdflatexfinal"
+            ]
+        },
+    ],
+    "latex-workshop.latex.tools": [
+        {
+            "name": "pdflatex",
+            "command": "pdflatex",
+            "args": [
+                "-synctex=1",
+                "-interaction=nonstopmode",
+                "-file-line-error",
+                "-shell-escape",
+                "-draftmode",
+                "-output-directory=%OUTDIR%",
+                "%DOC%"
+            ]
+        },
+        {
+            "name": "pdflatexfinal",
+            "command": "pdflatex",
+            "args": [
+                "-synctex=1",
+                "-interaction=nonstopmode",
+                "-file-line-error",
+                "-shell-escape",
+                "-output-directory=%OUTDIR%",
+                "%DOC%"
+            ]
+        },
+        {
+            "name": "bibtex",
+            "command": "bibtex",
+            "args": [
+                "%OUTDIR%/%DOCFILE%"
+            ]
+        },
+        {
+            "name": "makeindex",
+            "command": "makeindex",
+            "args": [
+                "%OUTDIR%/%DOCFILE%"
+            ]
+        }
+    ]
+}

--- a/fmfdelo.cls
+++ b/fmfdelo.cls
@@ -14,6 +14,7 @@
 \RequirePackage{etoolbox}
 \RequirePackage{ifthen}
 \RequirePackage{keyval}
+\RequirePackage{makeidx}
 
 \newcommand{\@ifthen}[2]{\ifthenelse{#1}{#2}{\relax}}
 \newcommand{\@unless}[2]{\ifthenelse{#1}{\relax}{#2}}
@@ -281,6 +282,9 @@
   \renewcommand{\listfigurename}{Kazalo slik}%
 }
 
+% generiraj vsebinsko kazalo
+\makeindex
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % IZPIS ZAČETNIH STRANI
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -433,6 +437,9 @@ Ljubljana, \@letnica}
 \@slovar
 \fi
 \ifdefined\@literatura
+\cleardoublepage
 \bibliography{\@literatura}
 \fi
+\cleardoublepage
+\printindex
 }


### PR DESCRIPTION
Sedaj zgenerira in izpiše kazalo (in študenti ne rabijo nič nastaviti v VS Code, da se požene `makeindex`).