### PR TITLE
Vrstni red šumnikov v stvarnem kazalu

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
             "tools": [
                 "pdflatex",
                 "bibtex",
-                "makeindex",
+                "texindy",
                 "pdflatex",
                 "pdflatexfinal"
             ]
@@ -46,10 +46,12 @@
             ]
         },
         {
-            "name": "makeindex",
-            "command": "makeindex",
+            "name": "texindy",
+            "command": "texindy",
             "args": [
-                "%OUTDIR%/%DOCFILE%"
+                "-Lslovenian",
+                "-Cutf8",
+                "%OUTDIR%/%DOCFILE%.idx"
             ]
         }
     ]


### PR DESCRIPTION
Po predlogu Luke Horjaka spreminjam `makeindex` v `xindy`, saj ta podpira slovenščino…

Preveriti bi bilo treba, kako se nastavitev `-L slovenian` obnaša v primeru angleščine (torej črke q). Poleg tega bi bilo praktično še preveriti, kako se uredijo grške črke (recimo ω-kompleks pričakujem pod o).
