### PR TITLE
Doda polji `url` in `urldate` v .bst

### DIFF
--- a/bibstyle/navodila.txt
+++ b/bibstyle/navodila.txt
@@ -73,6 +73,26 @@ FUNCTION {inproceedings}
 - pri format.booktitle izbriši emphasize, ker to predstavlja naslov proceedingov konference in ne naslovov knjige.
 - skopiraj master thesis in spremeni v bachelor thesis (dodaj nov tip bachelorsthesis)
 
-Potem skoraj celo stvar in prevedi izraze v slovenščino.
+- dodaj entry urldate, pri format.url dodaj funkcijo format.urldate, in popravi funkcijo format.url tako:
+
+FUNCTION {format.urldate}
+{
+  urldate
+  duplicate$ empty$
+    { pop$ "" }
+    { "[viewed " swap$ * "], accessible at " * }
+  if$
+}
+FUNCTION {format.url}
+{
+  url
+  duplicate$ empty$
+    { pop$ "" }
+    { format.urldate "\url{" * swap$ * "}" * }
+  if$
+}
+
+
+Potem skopiraj celo stvar in prevedi izraze v slovenščino.
 
 Shrani datoteko pod drugim imenom, da si je naslednjič ne povoziš.

--- a/bibstyle/stil.dbj
+++ b/bibstyle/stil.dbj
@@ -539,7 +539,7 @@ End of customized bst file
 %--------------------
 %URL ADDRESS: (without REVTeX fields)
     %: (def) No URL
-% url,url-blk,%: Include URL
+  url,url-blk,%: Include URL
 % url,url-nt,%: URL as note
 % url,url-nl,%: URL on new line
 %--------------------

--- a/fmf-en.bst
+++ b/fmf-en.bst
@@ -4,10 +4,10 @@
 %%
 %% The original source files were:
 %%
-%% merlin.mbs  (with options: `: (def) Numerical vonx,nm-init,ed-au,nmlm,x3,m1,dt-jnl,yr-com,xmth,tit-it,jttl-rm,vol-bf,vnum-sp,volp-blk,jdt-vs,pp-last,num-xser,ser-vol,jnm-x,pre-pub,doi,edpar,edby-par,edbyx,blk-com,in-col,pp,ed,abr,ednx,mth-bare,xedn,jabr,and-xcom,etal-xc,nfss,')
+%% merlin.mbs  (with options: `: (def) Numerical vonx,nm-init,ed-au,nmlm,x3,m1,dt-jnl,yr-com,xmth,tit-it,jttl-rm,vol-bf,vnum-sp,volp-blk,jdt-vs,pp-last,num-xser,ser-vol,jnm-x,pre-pub,doi,edpar,edby-par,edbyx,blk-com,in-col,pp,ed,abr,ednx,mth-bare,xedn,jabr,and-xcom,etal-xc,url,url-blk,nfss,')
 %% ----------------------------------------
 %% *** FMF Bachelor's and Master's thesis ***
-%%
+%% 
 %% Copyright 1994-2011 Patrick W Daly
  % ===============================================================
  % IMPORTANT NOTICE:
@@ -58,6 +58,8 @@ ENTRY
     series
     title
     type
+    url
+    urldate
     volume
     year
   }
@@ -387,6 +389,23 @@ FUNCTION {bibinfo.warn}
     }
   if$
 }
+FUNCTION {format.urldate}
+{
+  urldate
+  duplicate$ empty$
+    { pop$ "" }
+    { "[viewed " swap$ * "], accessible at " * }
+  if$
+}
+FUNCTION {format.url}
+{
+  url
+  duplicate$ empty$
+    { pop$ "" }
+    { format.urldate "\url{" * swap$ * "}" * }
+  if$
+}
+
 INTEGERS { nameptr namesleft numnames }
 
 
@@ -602,7 +621,7 @@ FUNCTION {format.bvolume}
       "volume" bibinfo.check * *
       series "series" bibinfo.check
       duplicate$ empty$ 'pop$
-        {" " * swap$ * }
+        { " " * swap$ * }
       if$
       "volume and number" number either.or.check
     }
@@ -930,6 +949,7 @@ FUNCTION {article}
     { format.journal.eid }
   if$
   format.doi output
+  format.url output
   format.note output
   fin.entry
 }
@@ -958,6 +978,7 @@ FUNCTION {book}
   format.edition output
   format.date "year" output.check
   format.doi output
+  format.url output
   format.note output
   fin.entry
 }
@@ -969,6 +990,7 @@ FUNCTION {booklet}
   address "address" bibinfo.check output
   format.date output
   format.doi output
+  format.url output
   format.note output
   fin.entry
 }
@@ -1003,6 +1025,7 @@ FUNCTION {inbook}
   date.block
   format.pages "pages" output.check
   format.doi output
+  format.url output
   format.note output
   fin.entry
 }
@@ -1027,6 +1050,7 @@ FUNCTION {incollection}
   date.block
   format.pages "pages" output.check
   format.doi output
+  format.url output
   format.note output
   fin.entry
 }
@@ -1052,6 +1076,7 @@ FUNCTION {inproceedings}
   date.block
   format.pages "pages" output.check
   format.doi output
+  format.url output
   format.note output
   fin.entry
 }
@@ -1085,6 +1110,7 @@ FUNCTION {manual}
   format.edition output
   format.date output
   format.doi output
+  format.url output
   format.note output
   fin.entry
 }
@@ -1099,6 +1125,7 @@ FUNCTION {mastersthesis}
   address "address" bibinfo.check output
   format.date "year" output.check
   format.doi output
+  format.url output
   format.note output
   fin.entry
 }
@@ -1113,6 +1140,7 @@ FUNCTION {bachelorsthesis}
   address "address" bibinfo.check output
   format.date "year" output.check
   format.doi output
+  format.url output
   format.note output
   fin.entry
 }
@@ -1124,6 +1152,7 @@ FUNCTION {misc}
   howpublished "howpublished" bibinfo.check output
   format.date output
   format.doi output
+  format.url output
   format.note output
   fin.entry
   empty.misc.check
@@ -1138,6 +1167,7 @@ FUNCTION {phdthesis}
   address "address" bibinfo.check output
   format.date "year" output.check
   format.doi output
+  format.url output
   format.note output
   fin.entry
 }
@@ -1172,6 +1202,7 @@ FUNCTION {proceedings}
   if$
       format.date "year" output.check
   format.doi output
+  format.url output
   format.note output
   fin.entry
 }
@@ -1186,6 +1217,7 @@ FUNCTION {techreport}
   address "address" bibinfo.check output
   format.date "year" output.check
   format.doi output
+  format.url output
   format.note output
   fin.entry
 }
@@ -1196,6 +1228,7 @@ FUNCTION {unpublished}
   format.title "title" output.check
   format.date output
   format.doi output
+  format.url output
   format.note "note" output.check
   fin.entry
 }
@@ -1374,6 +1407,10 @@ FUNCTION {begin.bib}
     { preamble$ write$ newline$ }
   if$
   "\begin{thebibliography}{"  longest.label  * "}" *
+  write$ newline$
+  "\providecommand{\url}[1]{\texttt{#1}}"
+  write$ newline$
+  "\providecommand{\urlprefix}{URL }"
   write$ newline$
   "\expandafter\ifx\csname urlstyle\endcsname\relax"
   write$ newline$

--- a/fmf-en.bst
+++ b/fmf-en.bst
@@ -394,7 +394,7 @@ FUNCTION {format.urldate}
   urldate
   duplicate$ empty$
     { pop$ "" }
-    { "[viewed " swap$ * "], accessible at " * }
+    { "[viewed " swap$ * "], " * }
   if$
 }
 FUNCTION {format.url}
@@ -402,7 +402,7 @@ FUNCTION {format.url}
   url
   duplicate$ empty$
     { pop$ "" }
-    { format.urldate "\url{" * swap$ * "}" * }
+    { format.urldate "accessible at \url{" * swap$ * "}" * }
   if$
 }
 

--- a/fmf-sl.bst
+++ b/fmf-sl.bst
@@ -4,10 +4,10 @@
 %%
 %% The original source files were:
 %%
-%% merlin.mbs  (with options: `: (def) Numerical vonx,nm-init,ed-au,nmlm,x3,m1,dt-jnl,yr-com,xmth,tit-it,jttl-rm,vol-bf,vnum-sp,volp-blk,jdt-vs,pp-last,num-xser,ser-vol,jnm-x,pre-pub,doi,edpar,edby-par,edbyx,blk-com,in-col,pp,ed,abr,ednx,mth-bare,xedn,jabr,and-xcom,etal-xc,nfss,')
+%% merlin.mbs  (with options: `: (def) Numerical vonx,nm-init,ed-au,nmlm,x3,m1,dt-jnl,yr-com,xmth,tit-it,jttl-rm,vol-bf,vnum-sp,volp-blk,jdt-vs,pp-last,num-xser,ser-vol,jnm-x,pre-pub,doi,edpar,edby-par,edbyx,blk-com,in-col,pp,ed,abr,ednx,mth-bare,xedn,jabr,and-xcom,etal-xc,url,url-blk,nfss,')
 %% ----------------------------------------
 %% *** FMF Bachelor's and Master's thesis ***
-%%
+%% 
 %% Copyright 1994-2011 Patrick W Daly
  % ===============================================================
  % IMPORTANT NOTICE:
@@ -58,6 +58,8 @@ ENTRY
     series
     title
     type
+    url
+    urldate
     volume
     year
   }
@@ -294,17 +296,17 @@ MACRO {mar} {"Mar."}
 
 MACRO {apr} {"Apr."}
 
-MACRO {may} {"May"}
+MACRO {may} {"Maj"}
 
 MACRO {jun} {"Jun."}
 
 MACRO {jul} {"Jul."}
 
-MACRO {aug} {"Aug."}
+MACRO {aug} {"Avg."}
 
 MACRO {sep} {"Sep."}
 
-MACRO {oct} {"Oct."}
+MACRO {oct} {"Okt."}
 
 MACRO {nov} {"Nov."}
 
@@ -387,6 +389,23 @@ FUNCTION {bibinfo.warn}
     }
   if$
 }
+FUNCTION {format.urldate}
+{
+  urldate
+  duplicate$ empty$
+    { pop$ "" }
+    { "[ogled " swap$ * "], dostopno na " * }
+  if$
+}
+FUNCTION {format.url}
+{
+  url
+  duplicate$ empty$
+    { pop$ "" }
+    { format.urldate "\url{" * swap$ * "}" * }
+  if$
+}
+
 INTEGERS { nameptr namesleft numnames }
 
 
@@ -602,7 +621,7 @@ FUNCTION {format.bvolume}
       "volume" bibinfo.check * *
       series "series" bibinfo.check
       duplicate$ empty$ 'pop$
-        {" " * swap$ * }
+        { " " * swap$ * }
       if$
       "volume and number" number either.or.check
     }
@@ -930,6 +949,7 @@ FUNCTION {article}
     { format.journal.eid }
   if$
   format.doi output
+  format.url output
   format.note output
   fin.entry
 }
@@ -958,6 +978,7 @@ FUNCTION {book}
   format.edition output
   format.date "year" output.check
   format.doi output
+  format.url output
   format.note output
   fin.entry
 }
@@ -969,6 +990,7 @@ FUNCTION {booklet}
   address "address" bibinfo.check output
   format.date output
   format.doi output
+  format.url output
   format.note output
   fin.entry
 }
@@ -1003,6 +1025,7 @@ FUNCTION {inbook}
   date.block
   format.pages "pages" output.check
   format.doi output
+  format.url output
   format.note output
   fin.entry
 }
@@ -1027,6 +1050,7 @@ FUNCTION {incollection}
   date.block
   format.pages "pages" output.check
   format.doi output
+  format.url output
   format.note output
   fin.entry
 }
@@ -1052,6 +1076,7 @@ FUNCTION {inproceedings}
   date.block
   format.pages "pages" output.check
   format.doi output
+  format.url output
   format.note output
   fin.entry
 }
@@ -1085,6 +1110,7 @@ FUNCTION {manual}
   format.edition output
   format.date output
   format.doi output
+  format.url output
   format.note output
   fin.entry
 }
@@ -1099,6 +1125,7 @@ FUNCTION {mastersthesis}
   address "address" bibinfo.check output
   format.date "year" output.check
   format.doi output
+  format.url output
   format.note output
   fin.entry
 }
@@ -1113,6 +1140,7 @@ FUNCTION {bachelorsthesis}
   address "address" bibinfo.check output
   format.date "year" output.check
   format.doi output
+  format.url output
   format.note output
   fin.entry
 }
@@ -1124,6 +1152,7 @@ FUNCTION {misc}
   howpublished "howpublished" bibinfo.check output
   format.date output
   format.doi output
+  format.url output
   format.note output
   fin.entry
   empty.misc.check
@@ -1138,6 +1167,7 @@ FUNCTION {phdthesis}
   address "address" bibinfo.check output
   format.date "year" output.check
   format.doi output
+  format.url output
   format.note output
   fin.entry
 }
@@ -1172,6 +1202,7 @@ FUNCTION {proceedings}
   if$
       format.date "year" output.check
   format.doi output
+  format.url output
   format.note output
   fin.entry
 }
@@ -1186,6 +1217,7 @@ FUNCTION {techreport}
   address "address" bibinfo.check output
   format.date "year" output.check
   format.doi output
+  format.url output
   format.note output
   fin.entry
 }
@@ -1196,6 +1228,7 @@ FUNCTION {unpublished}
   format.title "title" output.check
   format.date output
   format.doi output
+  format.url output
   format.note "note" output.check
   fin.entry
 }
@@ -1374,6 +1407,10 @@ FUNCTION {begin.bib}
     { preamble$ write$ newline$ }
   if$
   "\begin{thebibliography}{"  longest.label  * "}" *
+  write$ newline$
+  "\providecommand{\url}[1]{\texttt{#1}}"
+  write$ newline$
+  "\providecommand{\urlprefix}{URL }"
   write$ newline$
   "\expandafter\ifx\csname urlstyle\endcsname\relax"
   write$ newline$

--- a/fmf-sl.bst
+++ b/fmf-sl.bst
@@ -394,7 +394,7 @@ FUNCTION {format.urldate}
   urldate
   duplicate$ empty$
     { pop$ "" }
-    { "[ogled " swap$ * "], dostopno na " * }
+    { "[ogled " swap$ * "], " * }
   if$
 }
 FUNCTION {format.url}
@@ -402,7 +402,7 @@ FUNCTION {format.url}
   url
   duplicate$ empty$
     { pop$ "" }
-    { format.urldate "\url{" * swap$ * "}" * }
+    { format.urldate "dostopno na \url{" * swap$ * "}" * }
   if$
 }
 

--- a/predloge/diploma-primer/literatura.bib
+++ b/predloge/diploma-primer/literatura.bib
@@ -6,14 +6,14 @@
   series    = {Matematični rokopisi \textbf{25}},
   author    = {Josip Globevnik and Miha Brojan},
   publisher = {DMFA -- založništvo},
-  address   = {Ljubljana}
+  address   = {Ljubljana},
 }
 
 @book{lang,
   year      = {1999},
   publisher = {Springer New York},
   author    = {Serge Lang},
-  title     = {Fundamentals of Differential Geometry}
+  title     = {Fundamentals of Differential Geometry},
 }
 
 @article{zbornik,
@@ -25,7 +25,7 @@
   title     = {Singularities and Immersions},
   urldate   = {2023-01-01},
   volume    = {105},
-  year      = {1977}
+  year      = {1977},
 }
 
 @book{kalisnik,
@@ -33,15 +33,15 @@
   author    = {Kališnik, J. and Mrčun, J.},
   url       = {https://books.google.si/books?id=yhI8NQAACAAJ},
   year      = {2004},
-  publisher = {J. Kališnik}
+  publisher = {J. Kališnik},
 }
 
 @misc{wiki,
-  author = {{Wikipedia contributors}},
-  title  = {Matrix (mathematics) --- {Wikipedia}{,} The Free Encyclopedia},
-  year   = {2022},
-  url    = {https://en.wikipedia.org/w/index.php?title=Matrix_(mathematics)&oldid=1128559126},
-  note   = {[ogled 1.~1.~2023]}
+  author  = {{Wikipedia contributors}},
+  title   = {Matrix (mathematics) --- {Wikipedia}{,} The Free Encyclopedia},
+  year    = {2022},
+  url     = {https://en.wikipedia.org/w/index.php?title=Matrix_(mathematics)&oldid=1128559126},
+  urldate = {2023-01-01},
 }
 
 @article{vec-avtorjev,
@@ -54,6 +54,6 @@
   pages     = {88--140},
   month     = jan,
   year      = 2011,
-  language  = {en}
+  language  = {en},
 }
 

--- a/predloge/magisterij-primer-sl/literatura.bib
+++ b/predloge/magisterij-primer-sl/literatura.bib
@@ -1,12 +1,12 @@
 % Encoding: UTF-8
 
-@Misc{oeis,
+@misc{oeis,
   author = {N. J. A. Sloane},
   title  = {{The On-Line Encyclopedia of Integer Sequences, Sequence A005043}},
   note   = {[ogled 9.\ 7.\ 2016], dostopno na \url{http://oeis.org/A005043}},
 }
 
-@Book{zienkiewicz2000finite,
+@book{zienkiewicz2000finite,
   title     = {The Finite Element Method: Solid mechanics},
   publisher = {Butterworth-Heinemann},
   year      = {2000},
@@ -16,7 +16,7 @@
   address   = {Oxford},
 }
 
-@Article{liu2001point,
+@article{liu2001point,
   author    = {Liu, Gui-Rong and Gu, YuanTong},
   title     = {A point interpolation method for two-dimensional solids},
   journal   = {Int. J. Numer. Methods Eng.},
@@ -27,7 +27,7 @@
   publisher = {Wiley},
 }
 
-@Article{pereira2016convergence,
+@article{pereira2016convergence,
   author    = {Pereira, Kyvia and Bordas, Stephane and Tomar, Satyendra and Trobec, Roman and Depolli, Matjaz and Kosec, Gregor and Abdel Wahab, Magd},
   title     = {{On the convergence of stresses in fretting fatigue}},
   journal   = {Materials},
@@ -38,7 +38,7 @@
   publisher = {Multidisciplinary Digital Publishing Institute},
 }
 
-@Book{chen2006meshless,
+@book{chen2006meshless,
   title     = {Meshless Methods in Solid Mechanics},
   publisher = {Springer},
   year      = {2006},
@@ -47,7 +47,7 @@
   isbn      = {9780387333687},
 }
 
-@Book{trobec2015parallel,
+@book{trobec2015parallel,
   title     = {{Parallel scientific computing: theory, algorithms, and applications of mesh based and meshless methods}},
   publisher = {Springer},
   year      = {2015},
@@ -56,7 +56,7 @@
   address   = {New York},
 }
 
-@Book{gurtin1982introduction,
+@book{gurtin1982introduction,
   title     = {An Introduction to Continuum Mechanics},
   publisher = {Academic Press},
   year      = {1982},
@@ -67,7 +67,7 @@
   isbn      = {9780080918495},
 }
 
-@Book{lebedev2009introduction,
+@book{lebedev2009introduction,
   title     = {{Introduction to Mathematical Elasticity}},
   publisher = {World Scientific},
   year      = {2009},
@@ -75,21 +75,21 @@
   address   = {Singapur},
 }
 
-@PhdThesis{vene2000categorical,
+@phdthesis{vene2000categorical,
   author = {Vene, Varmo},
   title  = {Categorical programming with inductive and coinductive types},
   school = {Univerza v Tartuju},
   year   = {2000},
 }
 
-@MastersThesis{gregoric2017stopniceni,
+@mastersthesis{gregoric2017stopniceni,
   author = {Rok Gregorič},
   title  = {Stopničeni $E$-$\infty$ kolobarji in \textsf{Proj} v algebraični spektralni geometriji},
   school = {Fakulteta za matematiko in fiziko, Univerza v Ljubljani},
   year   = {2017},
 }
 
-@Bachelorsthesis{slak2015induktivni,
+@bachelorsthesis{slak2015induktivni,
   author = {Jure Slak},
   title  = {Induktivni in koinduktivni tipi},
   year   = {2015},
@@ -97,27 +97,29 @@
 }
 
 % key je ključ za sortiranje, nujen je ker manjka avtor
-@Misc{nsphere,
-  title = {$n$-sphere},
-  key   = {n-sphere},
-  note  = {[ogled 21.\ 8.\ 2017], dostopno na \url{https://en.wikipedia.org/wiki/N-sphere}},
+@misc{nsphere,
+  title   = {$n$-sphere},
+  key     = {n-sphere},
+  url     = {https://en.wikipedia.org/wiki/N-sphere},
+  urldate = {2022-08-24},
 }
 
 % dolge url-je se lahko ročno prelomi
-@Misc{STtemplate,
-  title  = {{DRAFT 2016 EU-wide ST templates}},
-  key    = {EU-wide ST templates},
-  note   = {[ogled 3.\ 8.\ 2016], dostopno na \href{http://www.eba.europa.eu/documents/10180/1259315/DRAFT+2016+EU-wide+ST+templates.xlsx}{\texttt{http://\\www.eba.europa.eu/documents/10180/1259315/DRAFT+2016+EU-wide+ST+\\templates.xlsx}}}
+@misc{STtemplate,
+  title = {{DRAFT 2016 EU-wide ST templates}},
+  key   = {EU-wide ST templates},
+  note  = {[ogled 3.\ 8.\ 2016], dostopno na \href{http://www.eba.europa.eu/documents/10180/1259315/DRAFT+2016+EU-wide+ST+templates.xlsx}{\texttt{http://\\www.eba.europa.eu/documents/10180/1259315/DRAFT+2016+EU-wide+ST+\\templates.xlsx}}},
 }
 
 % čudne znake (npr. %, #) v url-jih je potrebno escapati z \, torej (\%, \#).
-@Misc{NunbergerTand,
-  title = {{Nürnberger Tand}},
-  key   = {Nurnberger Tandl},
-  note  = {[ogled 23.\ 1.\ 2018], dostopno na \url{https://www.nuernbergwiki.de/index.php/N\%C3\%BCrnberger_Tand\#Geschichte}}
+@misc{NunbergerTand,
+  title   = {{Nürnberger Tand}},
+  key     = {Nurnberger Tandl},
+  url     = {https://www.nuernbergwiki.de/index.php/N\%C3\%BCrnberger_Tand\#Geschichte},
+  urldate = {2018-01-23},
 }
 
-@InProceedings{kibriya2007empirical,
+@inproceedings{kibriya2007empirical,
   author    = {Kibriya, Ashraf M. and Frank, Eibe},
   title     = {{An Empirical Comparison of Exact Nearest Neighbour Algorithms}},
   booktitle = {Knowledge Discovery in Databases: PKDD 2007: 11th European Conference on Principles and Practice of Knowledge Discovery in Databases, Warsaw, Poland, September 17-21, 2007. Proceedings},
@@ -131,7 +133,7 @@
   url       = {https://doi.org/10.1007/978-3-540-74976-9_16},
 }
 
-@Article{kearsley1975linearly,
+@article{kearsley1975linearly,
   author  = {Kearsley, Elliot A and Fong, JT},
   title   = {{Linearly independent sets of isotropic Cartesian tensors of ranks up to eight}},
   journal = {J. Res. Natl Bureau of Standards Part B: Math. Sci. B},


### PR DESCRIPTION
Manjka še formatiranje datuma v obliko d. m. yyyy (iz yyyy-mm-dd).
Ena možnost je, da se spiše date parser v .bst :scream:
Druga pa, da se uporabi paket `datetime2` (ali kaj podobnega), in se s tem formatira literaturo.

PS. trenutno se datum prepiše kot je, torej je tudi sprejemljivo, če rečemo, da morajo uporabniki pač napisati datum kot `1.~1.~2023`.