### PR TITLE
Formatiranje ključnih besed in vrstni red citatov v literaturi

### DIFF
--- a/fmfdelo.cls
+++ b/fmfdelo.cls
@@ -409,11 +409,11 @@
 \DeclareSourcemap{%
   \maps[datatype=bibtex]{
     \map[overwrite=false]{
-      \step[fieldsource=translator]
+      \step[fieldsource=author]
       \step[fieldset=sortname, origfieldval]
       \step[fieldsource=editor]
       \step[fieldset=sortname, origfieldval]
-      \step[fieldsource=author]
+      \step[fieldsource=translator]
       \step[fieldset=sortname, origfieldval]
     }
     \map[overwrite=false]{

--- a/fmfdelo.cls
+++ b/fmfdelo.cls
@@ -744,21 +744,21 @@
 \def\@frontpages@sl@kljucnebesede{
   \noindent
   \textbf{Math. Subj. Class. (2020):} \@klasifikacija \\[1mm]
-  \def\sep{, } % Pri izpisu ključne besede ločimo z vejico.
+  \def\sep{, }% Pri izpisu ključne besede ločimo z vejico.
   \textbf{Ključne besede:} \@kljucnebesede \\[1mm]
   \textbf{Keywords:} \@keywords
 }
 \def\@frontpages@en@keywords{
   \noindent
   \textbf{Math. Subj. Class. (2020):} \@klasifikacija \\[1mm]
-  \def\sep{, } % Pri izpisu ključne besede ločimo z vejico.
+  \def\sep{, }% Pri izpisu ključne besede ločimo z vejico.
   \textbf{Keywords:} \@keywords \\[1mm]
   \textbf{Ključne besede:} \@kljucnebesede
 }
 \def\@frontpages@trst@keywords{
   \noindent
   \textbf{Math. Subj. Class. (2020):} \@klasifikacija \\[1mm]
-  \def\sep{, } % Pri izpisu ključne besede ločimo z vejico.
+  \def\sep{, }% Pri izpisu ključne besede ločimo z vejico.
   \textbf{Keywords:} \@keywords \\[1mm]
   \textbf{Parole chiave:} \@it@keywords \\[1mm]
   \textbf{Ključne besede:} \@kljucnebesede


### PR DESCRIPTION
Občasno so ključne besede imele presledek na začetku vrstice, ker je bil na prejšnji vrstici trailing presledek.

Urejali smo vire najprej po urednikih in nato po avtorjih, kar sem popravila.